### PR TITLE
Flatten credentials v1 context and use 1.1 features.

### DIFF
--- a/contexts/credentials/v1
+++ b/contexts/credentials/v1
@@ -19,6 +19,7 @@
         "type": "@type",
 
         "cred": "https://www.w3.org/2018/credentials#",
+        "sec": "https://w3id.org/security#",
         "xsd": "http://www.w3.org/2001/XMLSchema#",
 
         "credentialSchema": {"@id": "cred:credentialSchema", "@type": "@id"},
@@ -47,6 +48,7 @@
         "type": "@type",
 
         "cred": "https://www.w3.org/2018/credentials#",
+        "sec": "https://w3id.org/security#",
 
         "holder": {"@id": "cred:holder", "@type": "@id"},
         "proof": {"@id": "sec:proof", "@type": "@id", "@container": "@graph"},

--- a/contexts/credentials/v1
+++ b/contexts/credentials/v1
@@ -18,7 +18,7 @@
         "id": "@id",
         "type": "@type",
 
-        "cred": "https://w3.org/2018/credentials#",
+        "cred": "https://www.w3.org/2018/credentials#",
         "xsd": "http://www.w3.org/2001/XMLSchema#",
 
         "credentialSchema": {"@id": "cred:credentialSchema", "@type": "@id"},
@@ -46,7 +46,7 @@
         "id": "@id",
         "type": "@type",
 
-        "cred": "https://w3.org/2018/credentials#",
+        "cred": "https://www.w3.org/2018/credentials#",
 
         "holder": {"@id": "cred:holder", "@type": "@id"},
         "proof": {"@id": "sec:proof", "@type": "@id", "@container": "@graph"},

--- a/contexts/credentials/v1
+++ b/contexts/credentials/v1
@@ -200,6 +200,8 @@
         "proofValue": "sec:proofValue",
         "verificationMethod": {"@id": "sec:verificationMethod", "@type": "@id"}
       }
-    }
+    },
+
+    "proof": {"@id": "https://w3id.org/security#proof", "@type": "@id", "@container": "@graph"}
   }
 }

--- a/contexts/credentials/v1
+++ b/contexts/credentials/v1
@@ -10,7 +10,7 @@
     "ManualRefreshService2018": "cred:ManualRefreshService2018",
 
     "VerifiableCredential": {
-      "@id": "cred:VerifiableCredential",
+      "@id": "https://www.w3.org/2018/credentials#VerifiableCredential",
       "@context": {
         "@version": 1.1,
         "@protected": true,
@@ -39,7 +39,7 @@
     },
 
     "VerifiablePresentation": {
-      "@id": "cred:VerifiablePresentation",
+      "@id": "https://www.w3.org/2018/credentials#VerifiablePresentation",
       "@context": {
         "@version": 1.1,
         "@protected": true,
@@ -57,7 +57,7 @@
     },
 
     "EcdsaSecp256k1Signature2019": {
-      "@id": "sec:EcdsaSecp256k1Signature2019",
+      "@id": "https://w3id.org/security#EcdsaSecp256k1Signature2019",
       "@context": {
         "@version": 1.1,
         "@protected": true,
@@ -95,7 +95,7 @@
     },
 
     "EcdsaSecp256r1Signature2019": {
-      "@id": "sec:EcdsaSecp256r1Signature2019",
+      "@id": "https://w3id.org/security#EcdsaSecp256r1Signature2019",
       "@context": {
         "@version": 1.1,
         "@protected": true,
@@ -133,7 +133,7 @@
     },
 
     "Ed25519Signature2018": {
-      "@id": "sec:Ed25519Signature2018",
+      "@id": "https://w3id.org/security#Ed25519Signature2018",
       "@context": {
         "@version": 1.1,
         "@protected": true,
@@ -171,7 +171,7 @@
     },
 
     "RsaSignature2018": {
-      "@id": "sec:RsaSignature2018",
+      "@id": "https://w3id.org/security#RsaSignature2018",
       "@context": {
         "@version": 1.1,
         "@protected": true,

--- a/contexts/credentials/v1
+++ b/contexts/credentials/v1
@@ -1,8 +1,10 @@
 {
-  "@context": [{
-    "@version": 1.1
-  }, "https://w3id.org/security/v2", {
+  "@context": {
+    "@version": 1.1,
+    "@protected": true,
+
     "cred": "https://w3.org/2018/credentials#",
+    "sec": "https://w3id.org/security#",
     "xsd": "http://www.w3.org/2001/XMLSchema#",
 
     "id": "@id",
@@ -10,19 +12,147 @@
 
     "JsonSchemaValidator2018": "cred:JsonSchemaValidator2018",
     "ManualRefreshService2018": "cred:ManualRefreshService2018",
-    "VerifiableCredential": "cred:VerifiableCredential",
-    "VerifiablePresentation": "cred:VerifiablePresentation",
 
-    "credentialSchema": {"@id": "cred:credentialSchema", "@type": "@id"},
-    "credentialStatus": {"@id": "cred:credentialStatus", "@type": "@id"},
-    "credentialSubject": {"@id": "cred:credentialSubject", "@type": "@id"},
-    "evidence": {"@id": "cred:evidence", "@type": "@id"},
-    "expirationDate": {"@id": "cred:expirationDate", "@type": "xsd:dateTime"},
-    "issuanceDate": {"@id": "cred:issuanceDate", "@type": "xsd:dateTime"},
-    "issuer": {"@id": "cred:issuer", "@type": "@id"},
-    "refreshService": {"@id": "cred:refreshService", "@type": "@id"},
-    "serviceEndpoint": {"@id": "cred:serviceEndpoint", "@type": "@id"},
-    "termsOfUse": {"@id": "cred:termsOfUse", "@type": "@id"},
-    "verifiableCredential": {"@id": "cred:verifiableCredential", "@type": "@id", "@container": "@graph"}
-  }]
+    "VerifiableCredential": {
+      "@id": "cred:VerifiableCredential",
+      "@context": {
+        "@version": 1.1,
+        "@protected": true,
+
+        "credentialSchema": {"@id": "cred:credentialSchema", "@type": "@id"},
+        "credentialStatus": {"@id": "cred:credentialStatus", "@type": "@id"},
+        "credentialSubject": {"@id": "cred:credentialSubject", "@type": "@id"},
+        "evidence": {"@id": "cred:evidence", "@type": "@id"},
+        "expirationDate": {"@id": "cred:expirationDate", "@type": "xsd:dateTime"},
+        "holder": {"@id": "cred:holder", "@type": "@id"},
+        "issuer": {"@id": "cred:issuer", "@type": "@id"},
+        "issuanceDate": {"@id": "cred:issuanceDate", "@type": "xsd:dateTime"},
+        "refreshService": {"@id": "cred:refreshService", "@type": "@id"},
+        "termsOfUse": {"@id": "cred:termsOfUse", "@type": "@id"},
+        "validFrom": {"@id": "cred:validFrom", "@type": "xsd:dateTime"},
+        "validUntil": {"@id": "cred:validUntil", "@type": "xsd:dateTime"}
+      }
+    },
+
+    "VerifiablePresentation": {
+      "@id": "cred:VerifiablePresentation",
+      "@context": {
+        "@version": 1.1,
+        "@protected": true,
+
+        "holder": {"@id": "cred:holder", "@type": "@id"},
+        "verifiableCredential": {"@id": "cred:verifiableCredential", "@type": "@id", "@container": "@graph"}
+      }
+    },
+
+    "EcdsaSecp256k1Signature2019": {
+      "@id": "sec:EcdsaSecp256k1Signature2019",
+      "@context": {
+        "@version": 1.1,
+        "@protected": true,
+
+        "challenge": "sec:challenge",
+        "created": {"@id": "http://purl.org/dc/terms/created", "@type": "xsd:dateTime"},
+        "domain": "sec:domain",
+        "expires": {"@id": "sec:expiration", "@type": "xsd:dateTime"},
+        "jws": "sec:jws",
+        "nonce": "sec:nonce",
+        "proofPurpose": {
+          "@id": "sec:proofPurpose", "@type": "@vocab",
+          "@context": {
+            "@version": 1.1,
+            "@protected": true,
+
+            "assertionMethod": {"@id": "sec:assertionMethod", "@type": "@id", "@container": "@set"},
+            "authentication": {"@id": "sec:authenticationMethod", "@type": "@id", "@container": "@set"}
+          }
+        },
+        "proofValue": "sec:proofValue",
+        "verificationMethod": {"@id": "sec:verificationMethod", "@type": "@id"}
+      }
+    },
+
+    "EcdsaSecp256r1Signature2019": {
+      "@id": "sec:EcdsaSecp256r1Signature2019",
+      "@context": {
+        "@version": 1.1,
+        "@protected": true,
+
+        "challenge": "sec:challenge",
+        "created": {"@id": "http://purl.org/dc/terms/created", "@type": "xsd:dateTime"},
+        "domain": "sec:domain",
+        "expires": {"@id": "sec:expiration", "@type": "xsd:dateTime"},
+        "jws": "sec:jws",
+        "nonce": "sec:nonce",
+        "proofPurpose": {
+          "@id": "sec:proofPurpose", "@type": "@vocab",
+          "@context": {
+            "@version": 1.1,
+            "@protected": true,
+
+            "assertionMethod": {"@id": "sec:assertionMethod", "@type": "@id", "@container": "@set"},
+            "authentication": {"@id": "sec:authenticationMethod", "@type": "@id", "@container": "@set"}
+          }
+        },
+        "proofValue": "sec:proofValue",
+        "verificationMethod": {"@id": "sec:verificationMethod", "@type": "@id"}
+      }
+    },
+
+    "Ed25519Signature2018": {
+      "@id": "sec:Ed25519Signature2018",
+      "@context": {
+        "@version": 1.1,
+        "@protected": true,
+
+        "challenge": "sec:challenge",
+        "created": {"@id": "http://purl.org/dc/terms/created", "@type": "xsd:dateTime"},
+        "domain": "sec:domain",
+        "expires": {"@id": "sec:expiration", "@type": "xsd:dateTime"},
+        "jws": "sec:jws",
+        "nonce": "sec:nonce",
+        "proofPurpose": {
+          "@id": "sec:proofPurpose", "@type": "@vocab",
+          "@context": {
+            "@version": 1.1,
+            "@protected": true,
+
+            "assertionMethod": {"@id": "sec:assertionMethod", "@type": "@id", "@container": "@set"},
+            "authentication": {"@id": "sec:authenticationMethod", "@type": "@id", "@container": "@set"}
+          }
+        },
+        "proofValue": "sec:proofValue",
+        "verificationMethod": {"@id": "sec:verificationMethod", "@type": "@id"}
+      }
+    },
+
+    "RsaSignature2018": {
+      "@id": "sec:RsaSignature2018",
+      "@context": {
+        "@version": 1.1,
+        "@protected": true,
+
+        "challenge": "sec:challenge",
+        "created": {"@id": "http://purl.org/dc/terms/created", "@type": "xsd:dateTime"},
+        "domain": "sec:domain",
+        "expires": {"@id": "sec:expiration", "@type": "xsd:dateTime"},
+        "jws": "sec:jws",
+        "nonce": "sec:nonce",
+        "proofPurpose": {
+          "@id": "sec:proofPurpose", "@type": "@vocab",
+          "@context": {
+            "@version": 1.1,
+            "@protected": true,
+
+            "assertionMethod": {"@id": "sec:assertionMethod", "@type": "@id", "@container": "@set"},
+            "authentication": {"@id": "sec:authenticationMethod", "@type": "@id", "@container": "@set"}
+          }
+        },
+        "proofValue": "sec:proofValue",
+        "verificationMethod": {"@id": "sec:verificationMethod", "@type": "@id"}
+      }
+    },
+
+    "proof": {"@id": "sec:proof", "@type": "@id", "@container": "@graph"}
+  }
 }

--- a/contexts/credentials/v1
+++ b/contexts/credentials/v1
@@ -3,10 +3,6 @@
     "@version": 1.1,
     "@protected": true,
 
-    "cred": "https://w3.org/2018/credentials#",
-    "sec": "https://w3id.org/security#",
-    "xsd": "http://www.w3.org/2001/XMLSchema#",
-
     "id": "@id",
     "type": "@type",
 
@@ -19,6 +15,12 @@
         "@version": 1.1,
         "@protected": true,
 
+        "id": "@id",
+        "type": "@type",
+
+        "cred": "https://w3.org/2018/credentials#",
+        "xsd": "http://www.w3.org/2001/XMLSchema#",
+
         "credentialSchema": {"@id": "cred:credentialSchema", "@type": "@id"},
         "credentialStatus": {"@id": "cred:credentialStatus", "@type": "@id"},
         "credentialSubject": {"@id": "cred:credentialSubject", "@type": "@id"},
@@ -27,6 +29,7 @@
         "holder": {"@id": "cred:holder", "@type": "@id"},
         "issuer": {"@id": "cred:issuer", "@type": "@id"},
         "issuanceDate": {"@id": "cred:issuanceDate", "@type": "xsd:dateTime"},
+        "proof": {"@id": "sec:proof", "@type": "@id", "@container": "@graph"},
         "refreshService": {"@id": "cred:refreshService", "@type": "@id"},
         "termsOfUse": {"@id": "cred:termsOfUse", "@type": "@id"},
         "validFrom": {"@id": "cred:validFrom", "@type": "xsd:dateTime"},
@@ -40,7 +43,13 @@
         "@version": 1.1,
         "@protected": true,
 
+        "id": "@id",
+        "type": "@type",
+
+        "cred": "https://w3.org/2018/credentials#",
+
         "holder": {"@id": "cred:holder", "@type": "@id"},
+        "proof": {"@id": "sec:proof", "@type": "@id", "@container": "@graph"},
         "verifiableCredential": {"@id": "cred:verifiableCredential", "@type": "@id", "@container": "@graph"}
       }
     },
@@ -50,6 +59,12 @@
       "@context": {
         "@version": 1.1,
         "@protected": true,
+
+        "id": "@id",
+        "type": "@type",
+
+        "sec": "https://w3id.org/security#",
+        "xsd": "http://www.w3.org/2001/XMLSchema#",
 
         "challenge": "sec:challenge",
         "created": {"@id": "http://purl.org/dc/terms/created", "@type": "xsd:dateTime"},
@@ -62,6 +77,11 @@
           "@context": {
             "@version": 1.1,
             "@protected": true,
+
+            "id": "@id",
+            "type": "@type",
+
+            "sec": "https://w3id.org/security#",
 
             "assertionMethod": {"@id": "sec:assertionMethod", "@type": "@id", "@container": "@set"},
             "authentication": {"@id": "sec:authenticationMethod", "@type": "@id", "@container": "@set"}
@@ -78,6 +98,12 @@
         "@version": 1.1,
         "@protected": true,
 
+        "id": "@id",
+        "type": "@type",
+
+        "sec": "https://w3id.org/security#",
+        "xsd": "http://www.w3.org/2001/XMLSchema#",
+
         "challenge": "sec:challenge",
         "created": {"@id": "http://purl.org/dc/terms/created", "@type": "xsd:dateTime"},
         "domain": "sec:domain",
@@ -89,6 +115,11 @@
           "@context": {
             "@version": 1.1,
             "@protected": true,
+
+            "id": "@id",
+            "type": "@type",
+
+            "sec": "https://w3id.org/security#",
 
             "assertionMethod": {"@id": "sec:assertionMethod", "@type": "@id", "@container": "@set"},
             "authentication": {"@id": "sec:authenticationMethod", "@type": "@id", "@container": "@set"}
@@ -105,6 +136,12 @@
         "@version": 1.1,
         "@protected": true,
 
+        "id": "@id",
+        "type": "@type",
+
+        "sec": "https://w3id.org/security#",
+        "xsd": "http://www.w3.org/2001/XMLSchema#",
+
         "challenge": "sec:challenge",
         "created": {"@id": "http://purl.org/dc/terms/created", "@type": "xsd:dateTime"},
         "domain": "sec:domain",
@@ -116,6 +153,11 @@
           "@context": {
             "@version": 1.1,
             "@protected": true,
+
+            "id": "@id",
+            "type": "@type",
+
+            "sec": "https://w3id.org/security#",
 
             "assertionMethod": {"@id": "sec:assertionMethod", "@type": "@id", "@container": "@set"},
             "authentication": {"@id": "sec:authenticationMethod", "@type": "@id", "@container": "@set"}
@@ -144,6 +186,11 @@
             "@version": 1.1,
             "@protected": true,
 
+            "id": "@id",
+            "type": "@type",
+
+            "sec": "https://w3id.org/security#",
+
             "assertionMethod": {"@id": "sec:assertionMethod", "@type": "@id", "@container": "@set"},
             "authentication": {"@id": "sec:authenticationMethod", "@type": "@id", "@container": "@set"}
           }
@@ -151,8 +198,6 @@
         "proofValue": "sec:proofValue",
         "verificationMethod": {"@id": "sec:verificationMethod", "@type": "@id"}
       }
-    },
-
-    "proof": {"@id": "sec:proof", "@type": "@id", "@container": "@graph"}
+    }
   }
 }


### PR DESCRIPTION
This is *likely* what we want for the credentials-v1 context, @yancyribbens. However, I'm still testing against the test suite.